### PR TITLE
feat: add OpenAI-compatible embedding backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,14 @@
 # For local embedding backend example:
 # ULTRON_EMBEDDING_BACKEND=local
 # ULTRON_EMBEDDING_MODEL=Qwen/Qwen3-Embedding-0.6B
+
+# For OpenAI-compatible embedding backend (OpenAI, Zhipu/GLM, vLLM/TEI, ...):
+# ULTRON_EMBEDDING_BACKEND=openai
+# ULTRON_EMBEDDING_MODEL=embedding-3
+# ULTRON_EMBEDDING_DIMENSION=2048
+# ULTRON_EMBEDDING_BASE_URL=https://open.bigmodel.cn/api/paas/v4   # falls back to ULTRON_BASE_URL
+# ULTRON_EMBEDDING_API_KEY=your-api-key                            # falls back to ULTRON_API_KEY / OPENAI_API_KEY
+
 # IMPORTANT: one ULTRON_DATA_DIR can only use one embedding backend/model/dimension.
 # If you switch embedding settings, run reset_all() first.
 

--- a/docs/en/Components/Config.md
+++ b/docs/en/Components/Config.md
@@ -6,7 +6,7 @@ description: UltronConfig, environment variables, and field reference
 
 # Configuration
 
-Ultron uses the `UltronConfig` dataclass for configuration. **`ULTRON_*` environment variables** supply defaults for each field; explicit arguments to `UltronConfig(...)` **override** the environment. The LLM uses an OpenAI-compatible surface (`llm_provider`, `llm_model`, `llm_base_url`, `llm_api_key`). Embeddings are selected by `embedding_backend` (`dashscope` or `local`); `dashscope_api_key` can share `DASHSCOPE_API_KEY` with the LLM and is written to `os.environ` on `Ultron(...)` init when set. `llm_api_key` resolves in order: `ULTRON_API_KEY` → `ULTRON_LLM_API_KEY` → `OPENAI_API_KEY` → `DASHSCOPE_API_KEY`.
+Ultron uses the `UltronConfig` dataclass for configuration. **`ULTRON_*` environment variables** supply defaults for each field; explicit arguments to `UltronConfig(...)` **override** the environment. The LLM uses an OpenAI-compatible surface (`llm_provider`, `llm_model`, `llm_base_url`, `llm_api_key`). Embeddings are selected by `embedding_backend` (`dashscope`, `openai`, or `local`); the `openai` backend talks to any OpenAI-compatible `/embeddings` endpoint (Zhipu/GLM, OpenAI, vLLM/TEI, ...) via `embedding_base_url`/`embedding_api_key`. `dashscope_api_key` can share `DASHSCOPE_API_KEY` with the LLM and is written to `os.environ` on `Ultron(...)` init when set. `llm_api_key` resolves in order: `ULTRON_API_KEY` → `ULTRON_LLM_API_KEY` → `OPENAI_API_KEY` → `DASHSCOPE_API_KEY`.
 
 On first import of `ultron.config` (or `import ultron`), `load_ultron_dotenv()` reads key/value pairs from `~/.ultron/.env` into `os.environ` (`override=False`).
 
@@ -49,7 +49,9 @@ ultron = Ultron(config=config)
 |-------|------|---------|-------------|
 | `embedding_model` | str | `text-embedding-v4` | DashScope TextEmbedding model name |
 | `embedding_dimension` | int | `1024` | Vector dimension (refined by the API after the first call) |
-| `embedding_backend` | str | `dashscope` | Embedding backend: `dashscope` or `local`; a single service data directory may use only one backend/model combination |
+| `embedding_backend` | str | `dashscope` | Embedding backend: `dashscope`, `openai`, or `local`; a single service data directory may use only one backend/model combination |
+| `embedding_base_url` | str | falls back to `ULTRON_BASE_URL` | `openai` backend only: OpenAI-compatible `/embeddings` root URL; env `ULTRON_EMBEDDING_BASE_URL` |
+| `embedding_api_key` | str | falls back to `ULTRON_API_KEY` / `OPENAI_API_KEY` | `openai` backend only: embedding service API key; env `ULTRON_EMBEDDING_API_KEY` |
 
 ### LLM configuration
 
@@ -177,6 +179,8 @@ HTTP logging: see [Installation](../GetStarted/Installation.md) (`ULTRON_LOG_LEV
 | `ULTRON_EMBEDDING_BACKEND` | `embedding_backend` |
 | `ULTRON_EMBEDDING_MODEL` | `embedding_model` |
 | `ULTRON_EMBEDDING_DIMENSION` | `embedding_dimension` |
+| `ULTRON_EMBEDDING_BASE_URL` | `embedding_base_url` |
+| `ULTRON_EMBEDDING_API_KEY` | `embedding_api_key` |
 | `ULTRON_CONVERSATION_EXTRACT_WINDOW_TOKENS` | `conversation_extract_window_tokens` |
 | `ULTRON_TRAJECTORY_MEMORY_SCORE_THRESHOLD` | `trajectory_memory_score_threshold` |
 | `ULTRON_TRAJECTORY_SFT_SCORE_THRESHOLD` | `trajectory_sft_score_threshold` |

--- a/docs/en/GetStarted/Installation.md
+++ b/docs/en/GetStarted/Installation.md
@@ -40,7 +40,7 @@ Ultron primarily calls LLM APIs, so a CPU-only machine is enough.
 
 ## Environment variables
 
-Smart ingestion and LLM-based classification need OpenAI-compatible LLM config. **Recommended**: set `ULTRON_LLM_PROVIDER`, `ULTRON_MODEL`, `ULTRON_BASE_URL`, and `ULTRON_API_KEY` in `~/.ultron/.env`. Embeddings still rely on `DASHSCOPE_API_KEY`.
+Smart ingestion and LLM-based classification need OpenAI-compatible LLM config. **Recommended**: set `ULTRON_LLM_PROVIDER`, `ULTRON_MODEL`, `ULTRON_BASE_URL`, and `ULTRON_API_KEY` in `~/.ultron/.env`. Embeddings default to `DASHSCOPE_API_KEY`; to use another model, set `ULTRON_EMBEDDING_BACKEND` to `local` (local sentence-transformers) or `openai` (any OpenAI-compatible `/embeddings` endpoint such as Zhipu `embedding-3`, OpenAI, vLLM/TEI, configured via `ULTRON_EMBEDDING_BASE_URL`/`ULTRON_EMBEDDING_API_KEY`).
 
 You can also export in the shell for one-off debugging:
 
@@ -60,8 +60,10 @@ Other optional variables (full `ULTRON_*` list in [Configuration](../Components/
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `ULTRON_EMBEDDING_MODEL` | TextEmbedding model name | `text-embedding-v4` |
-| `ULTRON_EMBEDDING_BACKEND` | Embedding backend (`dashscope` or `local`) | `dashscope` |
+| `ULTRON_EMBEDDING_BACKEND` | Embedding backend (`dashscope`, `openai`, or `local`) | `dashscope` |
 | `ULTRON_EMBEDDING_DIMENSION` | Vector dimension | `1024` |
+| `ULTRON_EMBEDDING_BASE_URL` | `openai` backend OpenAI-compatible `/embeddings` root URL (falls back to `ULTRON_BASE_URL`) | `""` |
+| `ULTRON_EMBEDDING_API_KEY` | `openai` backend API key (falls back to `ULTRON_API_KEY` / `OPENAI_API_KEY`) | `""` |
 | `ULTRON_LLM_PROVIDER` | OpenAI-compatible provider selector | `dashscope` |
 | `ULTRON_MODEL` | LLM for smart ingestion and extraction | `qwen3.6-flash` |
 | `ULTRON_MEMORY_CATEGORY_MODEL` | LLM for memory type classification | `qwen3.6-flash` |

--- a/docs/zh/Components/Config.md
+++ b/docs/zh/Components/Config.md
@@ -6,7 +6,7 @@ description: Ultron（奥创）配置说明
 
 # 配置
 
-Ultron 使用 `UltronConfig` 数据类进行配置管理。**环境变量 `ULTRON_*`** 决定各字段的默认值；在代码里构造 `UltronConfig(...)` 时传入的参数 **优先于** 环境变量。LLM 采用 OpenAI-compatible 抽象（`llm_provider`、`llm_model`、`llm_base_url`、`llm_api_key`）。向量嵌入由 `embedding_backend` 选择（`dashscope` 或 `local`）；`dashscope_api_key` 可与 LLM 共用 `DASHSCOPE_API_KEY`，并在 `Ultron(...)` 初始化时写入 `os.environ`（若已设置）。`llm_api_key` 的解析顺序为：`ULTRON_API_KEY` → `ULTRON_LLM_API_KEY` → `OPENAI_API_KEY` → `DASHSCOPE_API_KEY`。
+Ultron 使用 `UltronConfig` 数据类进行配置管理。**环境变量 `ULTRON_*`** 决定各字段的默认值；在代码里构造 `UltronConfig(...)` 时传入的参数 **优先于** 环境变量。LLM 采用 OpenAI-compatible 抽象（`llm_provider`、`llm_model`、`llm_base_url`、`llm_api_key`）。向量嵌入由 `embedding_backend` 选择（`dashscope`、`openai` 或 `local`）；当为 `openai` 时通过 `embedding_base_url`/`embedding_api_key` 对接任意 OpenAI-compatible 的 `/embeddings` 接口（如智谱、OpenAI、vLLM/TEI 等）；`dashscope_api_key` 可与 LLM 共用 `DASHSCOPE_API_KEY`，并在 `Ultron(...)` 初始化时写入 `os.environ`（若已设置）。`llm_api_key` 的解析顺序为：`ULTRON_API_KEY` → `ULTRON_LLM_API_KEY` → `OPENAI_API_KEY` → `DASHSCOPE_API_KEY`。
 
 首次导入 `ultron.config`（或 `import ultron`）时，会调用 `load_ultron_dotenv()`：从 `~/.ultron/.env` 读取键值并写入 `os.environ`（`override=False`）。
 
@@ -54,7 +54,9 @@ ultron = Ultron(config=config)
 | --------------------- | --- | ------------------- | --------------------------- |
 | `embedding_model`     | str | `text-embedding-v4` | DashScope TextEmbedding 模型名 |
 | `embedding_dimension` | int | `1024`              | 向量维度（首次调用后以 API 返回为准）       |
-| `embedding_backend`   | str | `dashscope`         | 嵌入后端，支持 `dashscope` 或 `local`；同一服务数据目录仅允许一种后端与模型组合 |
+| `embedding_backend`   | str | `dashscope`         | 嵌入后端，支持 `dashscope`、`openai` 或 `local`；同一服务数据目录仅允许一种后端与模型组合 |
+| `embedding_base_url`  | str | 回退 `ULTRON_BASE_URL` | 仅 `openai` 后端使用：OpenAI-compatible `/embeddings` 根 URL；环境变量 `ULTRON_EMBEDDING_BASE_URL` |
+| `embedding_api_key`   | str | 回退 `ULTRON_API_KEY` / `OPENAI_API_KEY` | 仅 `openai` 后端使用：嵌入服务 API Key；环境变量 `ULTRON_EMBEDDING_API_KEY` |
 
 
 ### LLM 配置
@@ -202,6 +204,8 @@ HTTP 日志见 [安装指南](../GetStarted/Installation.md)（`ULTRON_LOG_LEVEL
 | `ULTRON_EMBEDDING_BACKEND`                  | `embedding_backend`                  |
 | `ULTRON_EMBEDDING_MODEL`                    | `embedding_model`                    |
 | `ULTRON_EMBEDDING_DIMENSION`                | `embedding_dimension`                |
+| `ULTRON_EMBEDDING_BASE_URL`                 | `embedding_base_url`                 |
+| `ULTRON_EMBEDDING_API_KEY`                  | `embedding_api_key`                  |
 | `ULTRON_CONVERSATION_EXTRACT_WINDOW_TOKENS` | `conversation_extract_window_tokens` |
 | `ULTRON_TRAJECTORY_MEMORY_SCORE_THRESHOLD`  | `trajectory_memory_score_threshold`  |
 | `ULTRON_TRAJECTORY_SFT_SCORE_THRESHOLD`     | `trajectory_sft_score_threshold`     |

--- a/docs/zh/GetStarted/Installation.md
+++ b/docs/zh/GetStarted/Installation.md
@@ -44,7 +44,7 @@ Ultron 主要使用 LLM API，因此只需 CPU 环境即可运行。
 
 ## 环境变量
 
-智能摄取与 LLM 分类需要配置 OpenAI-compatible LLM 参数。**推荐**在 `**~/.ultron/.env`** 中设置 `ULTRON_LLM_PROVIDER`、`ULTRON_MODEL`、`ULTRON_BASE_URL`、`ULTRON_API_KEY`。向量嵌入仍使用 `DASHSCOPE_API_KEY`。
+智能摄取与 LLM 分类需要配置 OpenAI-compatible LLM 参数。**推荐**在 `**~/.ultron/.env`** 中设置 `ULTRON_LLM_PROVIDER`、`ULTRON_MODEL`、`ULTRON_BASE_URL`、`ULTRON_API_KEY`。向量嵌入默认使用 `DASHSCOPE_API_KEY`；如需改用其他模型，可将 `ULTRON_EMBEDDING_BACKEND` 设为 `local`（本地 sentence-transformers）或 `openai`（任意 OpenAI-compatible `/embeddings` 接口，如智谱 `embedding-3`、OpenAI、vLLM/TEI 等，通过 `ULTRON_EMBEDDING_BASE_URL`/`ULTRON_EMBEDDING_API_KEY` 配置）。
 
 也可在 shell 中导出（适用于一次性调试）：
 
@@ -65,8 +65,10 @@ export ULTRON_API_KEY="your-api-key"
 | 变量                             | 说明                  | 默认值                                     |
 | ------------------------------ | ------------------- | --------------------------------------- |
 | `ULTRON_EMBEDDING_MODEL`       | TextEmbedding 模型名   | `text-embedding-v4`                     |
-| `ULTRON_EMBEDDING_BACKEND`     | 嵌入后端（`dashscope` 或 `local`） | `dashscope`                     |
+| `ULTRON_EMBEDDING_BACKEND`     | 嵌入后端（`dashscope`、`openai` 或 `local`） | `dashscope`                     |
 | `ULTRON_EMBEDDING_DIMENSION`   | 向量维度                | `1024`                                  |
+| `ULTRON_EMBEDDING_BASE_URL`    | `openai` 后端的 OpenAI-compatible `/embeddings` 根 URL（未设时回退 `ULTRON_BASE_URL`） | `""` |
+| `ULTRON_EMBEDDING_API_KEY`     | `openai` 后端的 API Key（未设时回退 `ULTRON_API_KEY` / `OPENAI_API_KEY`） | `""` |
 | `ULTRON_LLM_PROVIDER`          | OpenAI-compatible 提供方标识 | `dashscope`                          |
 | `ULTRON_MODEL`                 | 智能摄取与记忆提取所用 LLM     | `qwen3.6-flash`                          |
 | `ULTRON_MEMORY_CATEGORY_MODEL` | 记忆类型分类所用 LLM        | `qwen3.6-flash`                         |

--- a/tests/core/test_embeddings.py
+++ b/tests/core/test_embeddings.py
@@ -6,6 +6,13 @@ from unittest.mock import MagicMock, patch
 
 from ultron.core.embeddings import HAS_DASHSCOPE, EmbeddingService
 
+try:
+    import openai  # noqa: F401
+
+    HAS_OPENAI = True
+except ImportError:
+    HAS_OPENAI = False
+
 
 class TestCosineSimilarity(unittest.TestCase):
     """Cosine similarity helper without DashScope."""
@@ -107,6 +114,120 @@ class TestDashScopeIntegration(unittest.TestCase):
                 with self.assertRaises(RuntimeError) as ctx:
                     svc.embed_text("x")
                 self.assertIn("quota", str(ctx.exception))
+
+
+class TestOpenAIBackendConfig(unittest.TestCase):
+    """OpenAI-compatible backend constructor validation."""
+
+    def test_unsupported_backend_raises(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            EmbeddingService(backend="zhipu")
+        self.assertIn("unsupported embedding backend", str(ctx.exception))
+
+    @unittest.skipUnless(HAS_OPENAI, "openai not installed")
+    def test_missing_base_url_raises(self):
+        with patch("openai.OpenAI"):
+            with self.assertRaises(RuntimeError) as ctx:
+                EmbeddingService(backend="openai", api_key="k", base_url="")
+            self.assertIn("base_url", str(ctx.exception))
+
+    @unittest.skipUnless(HAS_OPENAI, "openai not installed")
+    def test_missing_api_key_raises(self):
+        with patch("openai.OpenAI"):
+            with self.assertRaises(RuntimeError) as ctx:
+                EmbeddingService(
+                    backend="openai", api_key="", base_url="https://api.example/v1"
+                )
+            self.assertIn("api key", str(ctx.exception))
+
+
+class TestOpenAIBackendIntegration(unittest.TestCase):
+    """EmbeddingService 'openai' backend with a mocked OpenAI client."""
+
+    class _Item:
+        def __init__(self, embedding):
+            self.embedding = embedding
+
+    class _Resp:
+        def __init__(self, vectors):
+            self.data = [TestOpenAIBackendIntegration._Item(v) for v in vectors]
+
+    def _build(self, *, dimension_hint=1024):
+        """Return (service, mock_client) with OpenAI patched out."""
+        mock_client = MagicMock()
+        patcher = patch("openai.OpenAI", return_value=mock_client)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        svc = EmbeddingService(
+            backend="openai",
+            model_name="embedding-3",
+            base_url="https://api.example/v1",
+            api_key="test-key",
+            embedding_dimension_hint=dimension_hint,
+        )
+        return svc, mock_client
+
+    @unittest.skipUnless(HAS_OPENAI, "openai not installed")
+    def test_embed_text_updates_dimension(self):
+        vec = [0.1, 0.2, 0.3]
+        svc, client = self._build(dimension_hint=8)
+        client.embeddings.create.return_value = self._Resp([vec])
+        out = svc.embed_text("hello")
+        self.assertEqual(out, vec)
+        self.assertEqual(svc.dimension, 3)
+        self.assertTrue(svc.is_available())
+        client.embeddings.create.assert_called_once_with(
+            model="embedding-3", input=["hello"]
+        )
+
+    @unittest.skipUnless(HAS_OPENAI, "openai not installed")
+    def test_embed_texts_batch(self):
+        vectors = [[1.0, 0.0], [0.0, 1.0]]
+        svc, client = self._build()
+        client.embeddings.create.return_value = self._Resp(vectors)
+        out = svc.embed_texts(["a", "b"])
+        self.assertEqual(out, vectors)
+        self.assertEqual(svc.dimension, 2)
+
+    @unittest.skipUnless(HAS_OPENAI, "openai not installed")
+    def test_call_failure_raises(self):
+        svc, client = self._build()
+        client.embeddings.create.side_effect = RuntimeError("boom")
+        with self.assertRaises(RuntimeError) as ctx:
+            svc.embed_text("x")
+        self.assertIn("OpenAI-compatible embedding call failed", str(ctx.exception))
+
+    @unittest.skipUnless(HAS_OPENAI, "openai not installed")
+    def test_empty_data_raises(self):
+        svc, client = self._build()
+        client.embeddings.create.return_value = self._Resp([])
+        with self.assertRaises(RuntimeError) as ctx:
+            svc.embed_text("x")
+        self.assertIn("no data", str(ctx.exception))
+
+    @unittest.skipUnless(HAS_OPENAI, "openai not installed")
+    def test_empty_row_raises(self):
+        svc, client = self._build()
+        client.embeddings.create.return_value = self._Resp([[]])
+        with self.assertRaises(RuntimeError) as ctx:
+            svc.embed_text("x")
+        self.assertIn("empty row", str(ctx.exception))
+
+    @unittest.skipUnless(HAS_OPENAI, "openai not installed")
+    def test_count_mismatch_raises(self):
+        svc, client = self._build()
+        client.embeddings.create.return_value = self._Resp([[1.0, 2.0]])
+        with self.assertRaises(RuntimeError) as ctx:
+            svc.embed_texts(["a", "b"])
+        self.assertIn("count mismatch", str(ctx.exception))
+
+    @unittest.skipUnless(HAS_OPENAI, "openai not installed")
+    def test_model_info_reports_backend(self):
+        svc, _ = self._build()
+        info = svc.get_model_info()
+        self.assertEqual(info["backend"], "openai")
+        self.assertEqual(info["base_url"], "https://api.example/v1")
+        self.assertEqual(info["model_name"], "embedding-3")
 
 
 if __name__ == "__main__":

--- a/ultron/api/sdk/ultron.py
+++ b/ultron/api/sdk/ultron.py
@@ -67,6 +67,8 @@ class Ultron(MemoryMixin, SkillMixin, HarnessMixin, CoreMixin):
             model_name=self.config.embedding_model,
             embedding_dimension_hint=self.config.embedding_dimension,
             request_timeout_seconds=self.config.llm_request_timeout_seconds,
+            base_url=self.config.embedding_base_url,
+            api_key=self.config.embedding_api_key,
         )
         self._write_embedding_profile()
 

--- a/ultron/config.py
+++ b/ultron/config.py
@@ -71,6 +71,21 @@ class UltronConfig:
             os.environ.get("ULTRON_EMBEDDING_DIMENSION", "1024")
         )
     )
+    # OpenAI-compatible embedding backend (Zhipu/GLM, OpenAI, vLLM/TEI, ...).
+    # Used only when embedding_backend == "openai"; falls back to LLM endpoint/key.
+    embedding_base_url: str = field(
+        default_factory=lambda: (
+            os.environ.get("ULTRON_EMBEDDING_BASE_URL", "").strip()
+            or os.environ.get("ULTRON_BASE_URL", "").strip()
+        )
+    )
+    embedding_api_key: str = field(
+        default_factory=lambda: (
+            os.environ.get("ULTRON_EMBEDDING_API_KEY", "").strip()
+            or os.environ.get("ULTRON_API_KEY", "").strip()
+            or os.environ.get("OPENAI_API_KEY", "").strip()
+        )
+    )
 
     # Conversation extract: extra lines before ``new_lines`` for LLM context (no extra progress advance)
     session_extract_overlap_lines: int = field(

--- a/ultron/core/embeddings.py
+++ b/ultron/core/embeddings.py
@@ -17,8 +17,10 @@ except ImportError:
 
 class EmbeddingService:
     """
-    Embedding client with two backends:
+    Embedding client with three backends:
     - dashscope: default TextEmbedding API, requires DASHSCOPE_API_KEY.
+    - openai: any OpenAI-compatible /embeddings endpoint (OpenAI, Zhipu/GLM,
+      local vLLM/TEI, ...), configured via base_url + api_key + model_name.
     - local: sentence-transformers model loaded locally.
 
     Raises RuntimeError when required dependency/key is missing or backend call fails.
@@ -32,11 +34,14 @@ class EmbeddingService:
         *,
         embedding_dimension_hint: int = 1024,
         request_timeout_seconds: int = 300,
+        base_url: str = "",
+        api_key: str = "",
     ):
         self._backend = (backend or "dashscope").strip().lower()
-        if self._backend not in {"dashscope", "local"}:
+        if self._backend not in {"dashscope", "local", "openai"}:
             raise RuntimeError(
-                f"unsupported embedding backend: {self._backend}, expected dashscope or local"
+                f"unsupported embedding backend: {self._backend}, "
+                "expected dashscope, openai or local"
             )
 
         self.model_name = model_name
@@ -44,14 +49,45 @@ class EmbeddingService:
         env_dim = os.environ.get("ULTRON_EMBEDDING_DIMENSION", "").strip()
         self._dimension = int(env_dim) if env_dim else int(embedding_dimension_hint)
         self._local_model = None
+        self._base_url = (base_url or "").strip()
+        self._api_key = (api_key or "").strip()
+        self._openai_client = None
 
         if self._backend == "dashscope":
             if not HAS_DASHSCOPE:
                 raise RuntimeError(
                     "dashscope is not installed; run: pip install dashscope"
                 )
+        elif self._backend == "openai":
+            self._init_openai_client()
         else:
             self._init_local_model()
+
+    def _init_openai_client(self) -> None:
+        try:
+            from openai import OpenAI
+        except ImportError as e:
+            raise RuntimeError(
+                "openai is not installed; run: pip install openai"
+            ) from e
+        if not self._base_url:
+            raise RuntimeError(
+                "openai embedding backend requires a base_url "
+                "(set ULTRON_EMBEDDING_BASE_URL)"
+            )
+        if not self._api_key:
+            raise RuntimeError(
+                "openai embedding backend requires an api key "
+                "(set ULTRON_EMBEDDING_API_KEY)"
+            )
+        try:
+            self._openai_client = OpenAI(
+                api_key=self._api_key,
+                base_url=self._base_url,
+                timeout=self._request_timeout_seconds,
+            )
+        except Exception as e:
+            raise RuntimeError(f"failed to init OpenAI-compatible client: {e}") from e
 
     def _init_local_model(self) -> None:
         if not HAS_SENTENCE_TRANSFORMERS:
@@ -123,6 +159,40 @@ class EmbeddingService:
             )
         return rows
 
+    def _embed_openai(self, inputs: List[str]) -> List[List[float]]:
+        if not inputs:
+            return []
+        assert self._openai_client is not None
+        try:
+            resp = self._openai_client.embeddings.create(
+                model=self.model_name,
+                input=inputs,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"OpenAI-compatible embedding call failed: {e}"
+            ) from e
+
+        data = getattr(resp, "data", None) or []
+        if not data:
+            raise RuntimeError("OpenAI-compatible embedding response has no data")
+
+        rows: List[List[float]] = []
+        for item in data:
+            vec = getattr(item, "embedding", None)
+            if vec is None and isinstance(item, dict):
+                vec = item.get("embedding")
+            if not vec:
+                raise RuntimeError("OpenAI-compatible embedding returned an empty row")
+            rows.append([float(x) for x in vec])
+            self._dimension = len(rows[-1])
+
+        if len(rows) != len(inputs):
+            raise RuntimeError(
+                f"embedding count mismatch: got {len(rows)}, expected {len(inputs)}"
+            )
+        return rows
+
     def embed_text(self, text: str) -> List[float]:
         if not text or not text.strip():
             raise ValueError("cannot embed empty text")
@@ -134,6 +204,11 @@ class EmbeddingService:
             vec = [float(x) for x in rows[0]]
             self._dimension = len(vec)
             return vec
+        if self._backend == "openai":
+            rows = self._embed_openai([text])
+            if not rows:
+                raise RuntimeError("OpenAI-compatible embedding returned no vectors")
+            return rows[0]
         rows = self._embed_dashscope([text])
         if not rows:
             raise RuntimeError("DashScope TextEmbedding returned no vectors")
@@ -150,6 +225,8 @@ class EmbeddingService:
             if out:
                 self._dimension = len(out[0])
             return out
+        if self._backend == "openai":
+            return self._embed_openai(cleaned)
         return self._embed_dashscope(cleaned)
 
     @staticmethod
@@ -189,6 +266,8 @@ class EmbeddingService:
     def is_available(self) -> bool:
         if self._backend == "local":
             return self._local_model is not None
+        if self._backend == "openai":
+            return self._openai_client is not None and bool(self._api_key)
         return bool(os.environ.get("DASHSCOPE_API_KEY", "").strip()) and HAS_DASHSCOPE
 
     def get_model_info(self) -> dict:
@@ -197,6 +276,7 @@ class EmbeddingService:
             "model_name": self.model_name,
             "dimension": self._dimension,
             "is_available": self.is_available(),
+            "base_url": self._base_url if self._backend == "openai" else "",
             "has_dashscope": HAS_DASHSCOPE,
             "has_sentence_transformers": HAS_SENTENCE_TRANSFORMERS,
             "has_numpy": HAS_NUMPY,


### PR DESCRIPTION
## Summary

Adds a third embedding backend `openai` alongside the existing `dashscope` (default) and `local` backends. It works with any OpenAI-compatible `/embeddings` endpoint — OpenAI, Zhipu/GLM (`embedding-3`), self-hosted vLLM/TEI, etc. — configured via `base_url` + `api_key` + `model`.

Default behavior is unchanged: existing users stay on `dashscope` with no action required.

## Changes

- **`ultron/core/embeddings.py`**: `EmbeddingService` now supports `openai`. New `_init_openai_client()` (lazy-imports `openai`, validates `base_url`/`api_key`) and `_embed_openai()` with robust error handling for call failures, empty `data`, empty rows, and input/output count mismatches. The `openai` branch is wired into `embed_text` / `embed_texts` / `is_available` / `get_model_info`.
- **`ultron/config.py`**: new `embedding_base_url` and `embedding_api_key` fields. They fall back to the LLM endpoint/key (`ULTRON_BASE_URL`, `ULTRON_API_KEY` / `OPENAI_API_KEY`), so most users need no extra setup.
- **`ultron/api/sdk/ultron.py`**: passes the new config through to `EmbeddingService`.
- **Docs & `.env.example`**: document the new backend and env vars (`ULTRON_EMBEDDING_BASE_URL`, `ULTRON_EMBEDDING_API_KEY`) in both EN and ZH.
- **Tests**: `tests/core/test_embeddings.py` covers the `openai` backend success and error paths (skipped when `openai` is not installed).

## New environment variables

| Variable | Maps to | Fallback |
|----------|---------|----------|
| `ULTRON_EMBEDDING_BACKEND=openai` | `embedding_backend` | `dashscope` |
| `ULTRON_EMBEDDING_BASE_URL` | `embedding_base_url` | `ULTRON_BASE_URL` |
| `ULTRON_EMBEDDING_API_KEY` | `embedding_api_key` | `ULTRON_API_KEY` / `OPENAI_API_KEY` |

## Notes

- One `ULTRON_DATA_DIR` can only use a single embedding backend/model/dimension; switching requires `reset_all()` (existing constraint, unchanged).
- Requires the `openai` package only when this backend is selected.

## Test plan

- [x] `python -m pytest tests/core/test_embeddings.py`
- [x] Manual smoke test against a Zhipu `embedding-3` / OpenAI endpoint